### PR TITLE
Added LocalDB instance setup during ClassInit, and removed it at the …

### DIFF
--- a/Bungalow64.SqlTesting/Frameworks.MSTest2.Tests/Frameworks.MSTest2.Tests.csproj
+++ b/Bungalow64.SqlTesting/Frameworks.MSTest2.Tests/Frameworks.MSTest2.Tests.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.7" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/Bungalow64.SqlTesting/Frameworks.MSTest2/Frameworks.MSTest2.csproj
+++ b/Bungalow64.SqlTesting/Frameworks.MSTest2/Frameworks.MSTest2.csproj
@@ -20,7 +20,7 @@ This package is the test runner for MSTest2.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />
-		<PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+		<PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Bungalow64.SqlTesting/Frameworks.MSTest2/TestBase.cs
+++ b/Bungalow64.SqlTesting/Frameworks.MSTest2/TestBase.cs
@@ -14,8 +14,9 @@ namespace Frameworks.MSTest2
         public static void ClassInitialise(TestContext testContext)
         {
             Context = testContext;
+            SetUpDatabase();
         }
-        
+
         protected override string GetParameter(string parameterName)
         {
             if (Context != null && Context.Properties.Contains(parameterName))
@@ -30,5 +31,23 @@ namespace Frameworks.MSTest2
 
         [TestCleanup]
         public void Cleanup() => BaseCleanup();
+
+        [ClassCleanup(InheritanceBehavior.BeforeEachDerivedClass)]
+        public static void ClassCleanup()
+        {
+            DropDatabase();
+        }
+
+        [AssemblyInitialize()]
+        public static void AssemblyInitialize()
+        {
+
+        }
+
+        [AssemblyCleanup()]
+        public static void AssemblyCleanup()
+        {
+
+        }
     }
 }

--- a/Bungalow64.SqlTesting/Models/Models.csproj
+++ b/Bungalow64.SqlTesting/Models/Models.csproj
@@ -17,6 +17,7 @@ This package is the core logic; see the MSTest2/NUnit packages for the framework
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="MartinCostello.SqlLocalDb" Version="3.0.0" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="2.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.9" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />

--- a/Bungalow64.SqlTesting/Models/TestFrameworks/Abstract/BaseTestBase.cs
+++ b/Bungalow64.SqlTesting/Models/TestFrameworks/Abstract/BaseTestBase.cs
@@ -4,6 +4,7 @@ using Models.Factories;
 using Models.Factories.Abstract;
 using System;
 using System.Threading.Tasks;
+using MartinCostello.SqlLocalDb;
 
 namespace Models.TestFrameworks.Abstract
 {
@@ -62,6 +63,29 @@ namespace Models.TestFrameworks.Abstract
         protected void BaseCleanup()
         {
             TestRunner?.Dispose();
+        }
+
+        protected static TemporarySqlLocalDbInstance Database { get; set; }
+
+        protected static void SetUpDatabase()
+        {
+            using (var _databaseApi = new SqlLocalDbApi())
+            {
+                Database = _databaseApi.CreateTemporaryInstance();
+                Database.Manage().Start();
+            }
+        }
+
+        protected static void DropDatabase()
+        {
+            try
+            {
+                using (var _databaseApi = new SqlLocalDbApi())
+                {
+                    Database?.Dispose();
+                    Database = null;
+                }
+            } catch (Exception) { }
         }
     }
 }

--- a/Bungalow64.SqlTesting/Sample.Core.MSTest.Nuget.Tests/Sample.Core.MSTest.Nuget.Tests.csproj
+++ b/Bungalow64.SqlTesting/Sample.Core.MSTest.Nuget.Tests/Sample.Core.MSTest.Nuget.Tests.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Bungalow64.SqlTesting.MSTest2" Version="0.1.0-CI-20201015-113955" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/Bungalow64.SqlTesting/Sample.Core.MSTest.Tests/Sample.Core.MSTest.Tests.csproj
+++ b/Bungalow64.SqlTesting/Sample.Core.MSTest.Tests/Sample.Core.MSTest.Tests.csproj
@@ -19,8 +19,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0-rc.1.20451.14" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
 

--- a/Bungalow64.SqlTesting/Sample.Core.MSTest.Tests/Views/AllUsersTests.cs
+++ b/Bungalow64.SqlTesting/Sample.Core.MSTest.Tests/Views/AllUsersTests.cs
@@ -15,7 +15,7 @@ namespace Sample.Core.MSTest.Tests.Views
         public async Task AllUsers_NoData_NothingReturned()
         {
             QueryResult results = await TestRunner.ExecuteViewAsync("dbo.AllUsers");
-
+            
             results
                 .AssertRowCount(0);
 


### PR DESCRIPTION
…end.  Works fine some of the time, but errors when suite being run.  If it's already flaky, it's not a long-term solution.  Also updated to 2.1.2 for MSTest to fix ClassInit bug, but that's only needed if ClassInit is used for something useful.

Related Work Items: #66