### PR TITLE
#54 Added methods to check that a stored procedure/command results in…

### DIFF
--- a/docs/DBConfirm.Documentation/src/pages/Api.js
+++ b/docs/DBConfirm.Documentation/src/pages/Api.js
@@ -8,6 +8,7 @@ export default function Api() {
                 <li><a href="#queryresult">QueryResult object</a></li>
                 <li><a href="#rowresult">RowResult object</a></li>
                 <li><a href="#scalarresult">ScalarResult object</a></li>
+                <li><a href="#errorresult">ErrorResult object</a></li>
             </ul>
 
             <h2 id="testrunner">TestRunner API</h2>
@@ -185,6 +186,23 @@ export default function Api() {
             <p>Returns:</p>
             <ul>
                 <li>Returns the object returned from the stored procedure</li>
+            </ul>
+            <h3 id="executestoredprocedureerrorasync">ExecuteStoredProcedureErrorAsync</h3>
+            <p>Executes a stored procedure, returning the found error</p>
+            <pre><code className="lang-csharp"><span className="hljs-type">Task</span>&lt;<span className="hljs-type">ErrorResult</span>&gt; ExecuteStoredProcedureErrorAsync(<span className="hljs-keyword">string</span> procedureName, <span className="hljs-interface">IDictionary</span>&lt;<span className="hljs-keyword">string</span>, <span className="hljs-keyword">object</span>&gt; parameters)
+        {"\n"}
+                {"\n"}<span className="hljs-type">Task</span>&lt;<span className="hljs-type">ErrorResult</span>&gt; ExecuteStoredProcedureErrorAsync(<span className="hljs-keyword">string</span> procedureName, <span className="hljs-keyword">params</span> <span className="hljs-type">SqlQueryParameter</span>[] parameters)
+</code></pre>
+            <p>Parameters:</p>
+            <ul>
+                <li><strong>procedureName</strong> - The name of the stored procedure, including schema</li>
+                <li><strong>parameters</strong> - The parameters to be used (when an IDictionary is used, the Key is used as
+                the
+                parameter name, and the Value used as the parameter value)</li>
+            </ul>
+            <p>Returns:</p>
+            <ul>
+                <li>Returns the error returned from the stored procedure.  If no error is found, then the RawData within the ErrorResult object will be null</li>
             </ul>
             <h3 id="executetableasync">ExecuteTableAsync</h3>
             <p>Returns all data for a specific table</p>
@@ -563,6 +581,43 @@ export default function Api() {
             <p>Returns:</p>
             <ul>
                 <li>Returns the same <code>ScalarResult&lt;T&gt;</code> object</li>
+            </ul>
+            
+            <h2 id="errorresult">ErrorResult</h2>
+            <p>A single error is returned in an <code>ErrorResult</code> object, accessed via an error method in <code>TestRunner</code>. This object has assertion methods which can be used to test the error found.</p>
+            <h3 id="asserterror">AssertError</h3>
+            <p>Asserts that an error was found</p>
+            <pre><code className="lang-csharp"><span className="hljs-type">ErrorResult</span> AssertError()
+</code></pre>
+            <p>Returns:</p>
+            <ul>
+                <li>Returns the same <code>ErrorResult</code> object</li>
+            </ul>
+
+            <h3 id="assertmessage">AssertMessage</h3>
+            <p>Asserts that the error message matches the expected value.  If no error has been found, this assertion will fail</p>
+            <pre><code className="lang-csharp"><span className="hljs-type">ScalarResult</span> AssertMessage(<span className="hljs-keyword">object</span> expectedValue)
+            </code></pre>
+            <p>Parameters:</p>
+            <ul>
+                <li><strong>expectedValue</strong> - The expected value. Respects <code>IComparison</code> objects</li>
+            </ul>
+            <p>Returns:</p>
+            <ul>
+                <li>Returns the same <code>ErrorResult</code> object</li>
+            </ul>
+
+            <h3 id="asserttype">AssertType</h3>
+            <p>Asserts that the error type matches the expected type.  If no error has been found, this assertion will fail</p>
+            <pre><code className="lang-csharp"><span className="hljs-type">ScalarResult</span> AssertType(<span className="hljs-keyword">Type</span> expectedType)
+            </code></pre>
+            <p>Parameters:</p>
+            <ul>
+                <li><strong>expectedType</strong> - The expected type</li>
+            </ul>
+            <p>Returns:</p>
+            <ul>
+                <li>Returns the same <code>ErrorResult</code> object</li>
             </ul>
         </>
     );

--- a/docs/DBConfirm.Documentation/src/pages/WritingTests.js
+++ b/docs/DBConfirm.Documentation/src/pages/WritingTests.js
@@ -142,6 +142,7 @@ export default function WritingTests() {
                 <li><strong>ExecuteStoredProcedureMultipleDataSetAsync</strong> - returns a list of tables, each wrapped in a <code>QueryResult</code> object</li>
                 <li><strong>ExecuteStoredProcedureScalarAsync&lt;T&gt;</strong> - returns a single object, where <code>T</code> is the type of object</li>
                 <li><strong>ExecuteStoredProcedureNonQueryAsync</strong> - returns nothing</li>
+                <li><strong>ExecuteStoredProcedureErrorAsync</strong> - returns a single error, wrapped in an <code>ErrorResult</code> object</li>
             </ul>
 
             <p>Each method above takes the name of the stored procedure to execute (as a <code>string</code>), and an optional list of parameters.  The
@@ -170,6 +171,11 @@ export default function WritingTests() {
             {"\n"}
                 {"\n"}<span className="hljs-comment">{'//'} A stored procedure executed with no parameters, returning nothing</span>
                 {"\n"}<span className="hljs-function"><span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteStoredProcedureNonQueryAsync</span><span className="hljs-params">(<span className="hljs-string">"dbo.ProcessPendingCustomerOrders"</span>)</span></span>;
+                {"\n"}
+                {"\n"}<span className="hljs-comment">{'//'} A stored procedure executed, throwing an error</span>
+                {"\n"}<span className="hljs-type">ErrorResult</span> error1 = <span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteStoredProcedureErrorAsync</span>(<span className="hljs-string">"dbo.GetCustomerCount"</span>,
+            {"\n"}    <span className="hljs-keyword">new</span> <span className="hljs-type">SqlQueryParameter</span>(<span className="hljs-string">"MaxOrders"</span>, <span className="hljs-number">-1</span>),
+            {"\n"}    <span className="hljs-keyword">new</span> <span className="hljs-type">SqlQueryParameter</span>(<span className="hljs-string">"MaxValue"</span>, <span className="hljs-number">30</span>));
 </code></pre>
 
             <h4>Executing a view</h4>
@@ -191,6 +197,7 @@ export default function WritingTests() {
                 <li><strong>ExecuteCommandMultipleDataSetAsync</strong> - returns a list of tables, each wrapped in a <code>QueryResult</code> object</li>
                 <li><strong>ExecuteCommandScalarAsync&lt;T&gt;</strong> - returns a single object, where <code>T</code> is the type of object</li>
                 <li><strong>ExecuteCommandNonQueryAsync</strong> - returns nothing</li>
+                <li><strong>ExecuteCommandErrorAsync</strong> - returns a single error, wrapped in an <code>ErrorResult</code> object</li>
             </ul>
 
             <pre><code className="lang-csharp"><span className="hljs-comment">{'//'} A command executed with a single parameter, returning a data table</span>
@@ -214,6 +221,11 @@ export default function WritingTests() {
             {"\n"}
                 {"\n"}<span className="hljs-comment">{'//'} A command executed with no parameters, returning nothing</span>
                 {"\n"}<span className="hljs-function"><span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteCommandNoResultsAsync</span><span className="hljs-params">(<span className="hljs-string">"UPDATE dbo.Orders SET StatusID = 3"</span>)</span></span>;
+{"\n"}
+                {"\n"}<span className="hljs-comment">{'//'} A command executed, throwing an error</span>
+                {"\n"}<span className="hljs-type">ErrorResult</span> error1 = <span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteCommandErrorAsync</span>(<span className="hljs-string">"EXEC dbo.GetCustomerCount @MaxOrders, @MaxValue"</span>,
+            {"\n"}    <span className="hljs-keyword">new</span> <span className="hljs-type">SqlQueryParameter</span>(<span className="hljs-string">"MaxOrders"</span>, <span className="hljs-number">-1</span>),
+            {"\n"}    <span className="hljs-keyword">new</span> <span className="hljs-type">SqlQueryParameter</span>(<span className="hljs-string">"MaxValue"</span>, <span className="hljs-number">30</span>));
 </code></pre>
 
             <h3 id="assert">Assert - check the returned data, and check the state of data in the database</h3>
@@ -410,6 +422,34 @@ export default function WritingTests() {
             </code></pre>
 
             <p>Alternatively, you can use the <code>Comparisons.MatchesNumber</code> comparison object (see above) to assert on the numeric value, regardless of type.</p>
+
+            
+            <h4>ErrorResult assertions</h4>
+
+            <p><code>ErrorResult</code> represents a single error, and there are a few methods that can be used to make assertions on this error.  This is used to test whether the error you've experienced is what you're expecting.</p>
+
+<pre><code className="lang-csharp"><span className="hljs-type">ErrorResult</span> data = <span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteStoredProcedureErrorAsync</span>(<span className="hljs-string">"dbo.GetCount"</span>);
+        {"\n"}
+                {"\n"}data
+                {"\n"}    <span className="hljs-comment">{'//'} Asserts that the error was found</span>
+                {"\n"}    .<span className="hljs-title">AssertError</span>()
+        {"\n"}    <span className="hljs-comment">{'//'} Asserts that the message is 'Cannot insert the value NULL into column 'FirstName''</span>
+                {"\n"}    .<span className="hljs-title">AssertMessage</span>(<span className="hljs-string">"Cannot insert the value NULL into column 'FirstName'"</span>)
+        {"\n"}    <span className="hljs-comment">{'//'} Asserts that the message starts with 'Cannot insert the value NULL'</span>
+                {"\n"}    .<span className="hljs-title">AssertMessage</span>(Comparisons.<span className="hljs-title">StartsWith</span>(<span className="hljs-string">"Cannot insert the value NULL"</span>))
+        {"\n"}    <span className="hljs-comment">{'//'} Asserts that the exception type is 'SqlException'</span>
+                {"\n"}    .<span className="hljs-title">AssertType</span>(<span className="hljs-keyword">typeof</span>(<span className="hljs-type">SqlException</span>));
+</code></pre>
+
+
+
+
+            <p>To access the exception itself, you can call <code>ErrorResult.RawData</code>, which returns the value itself in case you need to do further assertions on it.</p>
+
+            <pre><code className="lang-csharp"><span className="hljs-type">ErrorResult</span> result = <span className="hljs-keyword">await</span> TestRunner.<span className="hljs-title">ExecuteStoredProcedureErrorAsync</span>(<span className="hljs-string">"dbo.GetCount"</span>);
+            {"\n"}<span className="hljs-comment">{'//'} Gets the exception</span>
+                {"\n"}<span className="hljs-type">Exception</span> resultValue = result.RawData;
+</code></pre>
         </>
     );
 }

--- a/src/Core/Comparisons/ExpectedData.cs
+++ b/src/Core/Comparisons/ExpectedData.cs
@@ -107,6 +107,24 @@ namespace DBConfirm.Core.Comparisons
         /// <returns>Returns the comparison object</returns>
         public IComparison NotMatchesRegex(string unexpectedRegex) => new NoMatchRegex(unexpectedRegex);
         /// <summary>
+        /// Gets the <see cref="IComparison"/> object to test for the data to start with a specific string  (case-sensitive)
+        /// </summary>
+        /// <param name="expected">The expected start string</param>
+        /// <returns>Returns the comparison object</returns>
+        public IComparison StartsWith(string expected) => new StartsWith(expected);
+        /// <summary>
+        /// Gets the <see cref="IComparison"/> object to test for the data to sendtart with a specific string  (case-sensitive)
+        /// </summary>
+        /// <param name="expected">The expected end string</param>
+        /// <returns>Returns the comparison object</returns>
+        public IComparison EndsWith(string expected) => new EndsWith(expected);
+        /// <summary>
+        /// Gets the <see cref="IComparison"/> object to test for the data to contain a specific string  (case-sensitive)
+        /// </summary>
+        /// <param name="expected">The expected contents</param>
+        /// <returns>Returns the comparison object</returns>
+        public IComparison Contains(string expected) => new Contains(expected);
+        /// <summary>
         /// Gets the <see cref="IComparison"/> object to test for the data to match a specific type
         /// </summary>
         /// <param name="expectedType">The expected type</param>

--- a/src/Core/Comparisons/Strings/Contains.cs
+++ b/src/Core/Comparisons/Strings/Contains.cs
@@ -1,0 +1,49 @@
+﻿using DBConfirm.Core.Comparisons.Abstract;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using System;
+
+namespace DBConfirm.Core.Comparisons.Strings
+{
+    /// <summary>
+    /// Asserts that a value contains a specific string (case-sensitive)
+    /// </summary>
+    public class Contains : IComparison
+    {
+        /// <summary>
+        /// The expected string
+        /// </summary>
+        public string Expected { get; }
+
+        /// <summary>
+        /// Constructor, setting the expected string
+        /// </summary>
+        /// <param name="expected">The expected contents</param>
+        public Contains(string expected)
+        {
+            if (string.IsNullOrEmpty(expected))
+            {
+                throw new ArgumentException("Expected string cannot be null or empty", nameof(expected));
+            }
+            Expected = expected;
+        }
+
+        /// <inheritdoc/>
+        public void Assert(ITestFramework testFramework, object value, string messagePrefix)
+        {
+            testFramework.IsInstanceOfType(value, typeof(string), $"{messagePrefix} is not a valid String object");
+
+            testFramework.Contains((string)value, Expected, $"{messagePrefix} does not contain the expected string");
+        }
+
+        /// <inheritdoc/>
+        public bool Validate(object value)
+        {
+            if (!(value is string))
+            {
+                return false;
+            }
+
+            return ((string)value)?.Contains(Expected) ?? false;
+        }
+    }
+}

--- a/src/Core/Comparisons/Strings/EndsWith.cs
+++ b/src/Core/Comparisons/Strings/EndsWith.cs
@@ -1,0 +1,49 @@
+﻿using DBConfirm.Core.Comparisons.Abstract;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using System;
+
+namespace DBConfirm.Core.Comparisons.Strings
+{
+    /// <summary>
+    /// Asserts that a value ends with a specific string (case-sensitive)
+    /// </summary>
+    public class EndsWith : IComparison
+    {
+        /// <summary>
+        /// The expected end string
+        /// </summary>
+        public string Expected { get; }
+
+        /// <summary>
+        /// Constructor, setting the expected end string
+        /// </summary>
+        /// <param name="expected">The expected end string</param>
+        public EndsWith(string expected)
+        {
+            if (string.IsNullOrEmpty(expected))
+            {
+                throw new ArgumentException("Expected string cannot be null or empty", nameof(expected));
+            }
+            Expected = expected;
+        }
+
+        /// <inheritdoc/>
+        public void Assert(ITestFramework testFramework, object value, string messagePrefix)
+        {
+            testFramework.IsInstanceOfType(value, typeof(string), $"{messagePrefix} is not a valid String object");
+
+            testFramework.EndsWith((string)value, Expected, $"{messagePrefix} does not end with the expected string");
+        }
+
+        /// <inheritdoc/>
+        public bool Validate(object value)
+        {
+            if (!(value is string))
+            {
+                return false;
+            }
+
+            return ((string)value)?.EndsWith(Expected) ?? false;
+        }
+    }
+}

--- a/src/Core/Comparisons/Strings/StartsWith.cs
+++ b/src/Core/Comparisons/Strings/StartsWith.cs
@@ -1,0 +1,49 @@
+﻿using DBConfirm.Core.Comparisons.Abstract;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using System;
+
+namespace DBConfirm.Core.Comparisons.Strings
+{
+    /// <summary>
+    /// Asserts that a value starts with a specific string (case-sensitive)
+    /// </summary>
+    public class StartsWith : IComparison
+    {
+        /// <summary>
+        /// The expected start string
+        /// </summary>
+        public string Expected { get; }
+
+        /// <summary>
+        /// Constructor, setting the expected start string
+        /// </summary>
+        /// <param name="expected">The expected start string</param>
+        public StartsWith(string expected)
+        {
+            if (string.IsNullOrEmpty(expected))
+            {
+                throw new ArgumentException("Expected string cannot be null or empty", nameof(expected));
+            }
+            Expected = expected;
+        }
+
+        /// <inheritdoc/>
+        public void Assert(ITestFramework testFramework, object value, string messagePrefix)
+        {
+            testFramework.IsInstanceOfType(value, typeof(string), $"{messagePrefix} is not a valid String object");
+
+            testFramework.StartsWith((string)value, Expected, $"{messagePrefix} does not start with the expected string");
+        }
+
+        /// <inheritdoc/>
+        public bool Validate(object value)
+        {
+            if (!(value is string))
+            {
+                return false;
+            }
+
+            return ((string)value)?.StartsWith(Expected) ?? false;
+        }
+    }
+}

--- a/src/Core/DataResults/ErrorResult.cs
+++ b/src/Core/DataResults/ErrorResult.cs
@@ -1,0 +1,82 @@
+﻿using DBConfirm.Core.TestFrameworks.Abstract;
+using DBConfirm.Core.Validation;
+using System;
+
+namespace DBConfirm.Core.DataResults
+{
+    /// <summary>
+    /// The data for a specific error
+    /// </summary>
+    public class ErrorResult
+    {
+        /// <summary>
+        /// The details of the thrown error
+        /// </summary>
+        public Exception RawData { get; private set; }
+
+        /// <summary>
+        /// The test framework to use for assertions
+        /// </summary>
+        internal readonly ITestFramework TestFramework;
+
+        /// <summary>
+        /// Constructor, including the test framework and the error data
+        /// </summary>
+        /// <param name="testFramework">The test framework to use for assertions</param>
+        /// <param name="rawData">The error returned from the query execution</param>
+        public ErrorResult(ITestFramework testFramework, Exception rawData)
+        {
+            TestFramework = testFramework;
+            RawData = rawData;
+        }
+
+        /// <summary>
+        /// Asserts that an error was found
+        /// </summary>
+        /// <returns>Returns the same <see cref="ErrorResult"/> object</returns>
+        public ErrorResult AssertError()
+        {
+            if (RawData is null)
+            {
+                TestFramework.Fail("No error was found");
+                return this;
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Asserts that the error message matches the expected value.  If no error has been found, this assertion will fail
+        /// </summary>
+        /// <param name="expectedValue">The expected message.  Respects <see cref="Comparisons.Abstract.IComparison"/> objects</param>
+        /// <returns>Returns the same <see cref="ErrorResult"/> object</returns>
+        public ErrorResult AssertMessage(object expectedValue)
+        {
+            if (RawData is null)
+            {
+                TestFramework.Fail("No error was found");
+                return this;
+            }
+            ValueValidation.Assert(TestFramework, expectedValue, RawData?.Message, $"Error result", useDBNull: false);
+
+            return this;
+        }
+
+        /// <summary>
+        /// Asserts that the error type matches the expected type.  If no error has been found, this assertion will fail
+        /// </summary>
+        /// <param name="expectedType">The expected type</param>
+        /// <returns>Returns the same <see cref="ErrorResult"/> object</returns>
+        public ErrorResult AssertType(Type expectedType)
+        {
+            if (RawData is null)
+            {
+                TestFramework.Fail("No error was found");
+                return this;
+            }
+            ValueValidation.Assert(TestFramework, expectedType, RawData?.GetType(), $"Error result", useDBNull: false);
+
+            return this;
+        }
+    }
+}

--- a/src/Core/Documentation/DBConfirm.Core.xml
+++ b/src/Core/Documentation/DBConfirm.Core.xml
@@ -301,6 +301,27 @@
             <param name="unexpectedRegex">The regex to not match</param>
             <returns>Returns the comparison object</returns>
         </member>
+        <member name="M:DBConfirm.Core.Comparisons.ExpectedData.StartsWith(System.String)">
+            <summary>
+            Gets the <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object to test for the data to start with a specific string  (case-sensitive)
+            </summary>
+            <param name="expected">The expected start string</param>
+            <returns>Returns the comparison object</returns>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.ExpectedData.EndsWith(System.String)">
+            <summary>
+            Gets the <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object to test for the data to sendtart with a specific string  (case-sensitive)
+            </summary>
+            <param name="expected">The expected end string</param>
+            <returns>Returns the comparison object</returns>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.ExpectedData.Contains(System.String)">
+            <summary>
+            Gets the <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object to test for the data to contain a specific string  (case-sensitive)
+            </summary>
+            <param name="expected">The expected contents</param>
+            <returns>Returns the comparison object</returns>
+        </member>
         <member name="M:DBConfirm.Core.Comparisons.ExpectedData.IsType(System.Type)">
             <summary>
             Gets the <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object to test for the data to match a specific type
@@ -437,6 +458,50 @@
         <member name="M:DBConfirm.Core.Comparisons.States.NullState.Validate(System.Object)">
             <inheritdoc/>
         </member>
+        <member name="T:DBConfirm.Core.Comparisons.Strings.Contains">
+            <summary>
+            Asserts that a value contains a specific string (case-sensitive)
+            </summary>
+        </member>
+        <member name="P:DBConfirm.Core.Comparisons.Strings.Contains.Expected">
+            <summary>
+            The expected string
+            </summary>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.Contains.#ctor(System.String)">
+            <summary>
+            Constructor, setting the expected string
+            </summary>
+            <param name="expected">The expected contents</param>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.Contains.Assert(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Object,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.Contains.Validate(System.Object)">
+            <inheritdoc/>
+        </member>
+        <member name="T:DBConfirm.Core.Comparisons.Strings.EndsWith">
+            <summary>
+            Asserts that a value ends with a specific string (case-sensitive)
+            </summary>
+        </member>
+        <member name="P:DBConfirm.Core.Comparisons.Strings.EndsWith.Expected">
+            <summary>
+            The expected end string
+            </summary>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.EndsWith.#ctor(System.String)">
+            <summary>
+            Constructor, setting the expected end string
+            </summary>
+            <param name="expected">The expected end string</param>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.EndsWith.Assert(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Object,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.EndsWith.Validate(System.Object)">
+            <inheritdoc/>
+        </member>
         <member name="T:DBConfirm.Core.Comparisons.Strings.MatchRegex">
             <summary>
             Asserts that a value matches a regex pattern
@@ -515,6 +580,28 @@
         <member name="M:DBConfirm.Core.Comparisons.Strings.SpecificLength.Validate(System.Object)">
             <inheritdoc/>
         </member>
+        <member name="T:DBConfirm.Core.Comparisons.Strings.StartsWith">
+            <summary>
+            Asserts that a value starts with a specific string (case-sensitive)
+            </summary>
+        </member>
+        <member name="P:DBConfirm.Core.Comparisons.Strings.StartsWith.Expected">
+            <summary>
+            The expected start string
+            </summary>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.StartsWith.#ctor(System.String)">
+            <summary>
+            Constructor, setting the expected start string
+            </summary>
+            <param name="expected">The expected start string</param>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.StartsWith.Assert(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Object,System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Core.Comparisons.Strings.StartsWith.Validate(System.Object)">
+            <inheritdoc/>
+        </member>
         <member name="T:DBConfirm.Core.Comparisons.Types.MatchType">
             <summary>
             Asserts that a value is of a specific type
@@ -536,6 +623,48 @@
         </member>
         <member name="M:DBConfirm.Core.Comparisons.Types.MatchType.Validate(System.Object)">
             <inheritdoc/>
+        </member>
+        <member name="T:DBConfirm.Core.DataResults.ErrorResult">
+            <summary>
+            The data for a specific error
+            </summary>
+        </member>
+        <member name="P:DBConfirm.Core.DataResults.ErrorResult.RawData">
+            <summary>
+            The details of the thrown error
+            </summary>
+        </member>
+        <member name="F:DBConfirm.Core.DataResults.ErrorResult.TestFramework">
+            <summary>
+            The test framework to use for assertions
+            </summary>
+        </member>
+        <member name="M:DBConfirm.Core.DataResults.ErrorResult.#ctor(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Exception)">
+            <summary>
+            Constructor, including the test framework and the error data
+            </summary>
+            <param name="testFramework">The test framework to use for assertions</param>
+            <param name="rawData">The error returned from the query execution</param>
+        </member>
+        <member name="M:DBConfirm.Core.DataResults.ErrorResult.AssertError">
+            <summary>
+            Asserts that an error was found
+            </summary>
+            <returns>Returns the same <see cref="T:DBConfirm.Core.DataResults.ErrorResult"/> object</returns>
+        </member>
+        <member name="M:DBConfirm.Core.DataResults.ErrorResult.AssertMessage(System.Object)">
+            <summary>
+            Asserts that the error message matches the expected value.  If no error has been found, this assertion will fail
+            </summary>
+            <param name="expectedValue">The expected message.  Respects <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> objects</param>
+            <returns>Returns the same <see cref="T:DBConfirm.Core.DataResults.ErrorResult"/> object</returns>
+        </member>
+        <member name="M:DBConfirm.Core.DataResults.ErrorResult.AssertType(System.Type)">
+            <summary>
+            Asserts that the error type matches the expected type.  If no error has been found, this assertion will fail
+            </summary>
+            <param name="expectedType">The expected type</param>
+            <returns>Returns the same <see cref="T:DBConfirm.Core.DataResults.ErrorResult"/> object</returns>
         </member>
         <member name="T:DBConfirm.Core.DataResults.QueryResult">
             <summary>
@@ -1068,6 +1197,22 @@
             <exception cref="T:System.Data.Common.DbException"></exception>
             <exception cref="T:System.InvalidCastException"></exception>
         </member>
+        <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteCommandErrorAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
+            <summary>
+            Executes a command, returning the found error
+            </summary>
+            <param name="commandText">The command to execute</param>
+            <param name="parameters">The parameters to be used.  The Key is used as the parameter name, and the Value used as the parameter value</param>
+            <returns>Returns the error returned from the command. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        </member>
+        <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteCommandErrorAsync(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
+            <summary>
+            Executes a command, returning the found error
+            </summary>
+            <param name="commandText">The command to execute</param>
+            <param name="parameters">The parameters to be used</param>
+            <returns>Returns the error returned from the command. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        </member>
         <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteStoredProcedureMultipleDataSetAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
             <summary>
             Executes a stored procedure, returning all data tables
@@ -1143,6 +1288,22 @@
             <returns>Returns the object returned from the stored procedure</returns>
             <exception cref="T:System.Data.Common.DbException"></exception>
             <exception cref="T:System.InvalidCastException"></exception>
+        </member>
+        <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteStoredProcedureErrorAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
+            <summary>
+            Executes a stored procedure, returning the found error
+            </summary>
+            <param name="procedureName">The name of the stored procedure, including schema</param>
+            <param name="parameters">The parameters to be used.  The Key is used as the parameter name, and the Value used as the parameter value</param>
+            <returns>Returns the error returned from the stored procedure. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        </member>
+        <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteStoredProcedureErrorAsync(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
+            <summary>
+            Executes a stored procedure, returning the found error
+            </summary>
+            <param name="procedureName">The name of the stored procedure, including schema</param>
+            <param name="parameters">The parameters to be used</param>
+            <returns>Returns the error returned from the stored procedure. If no error is found, then the RawData within the ErrorResult object will be null</returns>
         </member>
         <member name="M:DBConfirm.Core.Runners.Abstract.ITestRunner.ExecuteTableAsync(System.String)">
             <summary>
@@ -1549,6 +1710,33 @@
             <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
             <param name="parameters">An array of parameters to use when formatting message</param>
         </member>
+        <member name="M:DBConfirm.Core.TestFrameworks.Abstract.ITestFramework.StartsWith(System.String,System.String,System.String,System.String[])">
+            <summary>
+            Asserts that the value starts with the expected string
+            </summary>
+            <param name="actual">The actual value to test</param>
+            <param name="expected">The string with which the value is expected to start</param>
+            <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+            <param name="parameters">An array of parameters to use when formatting message</param>
+        </member>
+        <member name="M:DBConfirm.Core.TestFrameworks.Abstract.ITestFramework.EndsWith(System.String,System.String,System.String,System.String[])">
+            <summary>
+            Asserts that the value ends with the expected string
+            </summary>
+            <param name="actual">The actual value to test</param>
+            <param name="expected">The string with which the value is expected to end</param>
+            <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+            <param name="parameters">An array of parameters to use when formatting message</param>
+        </member>
+        <member name="M:DBConfirm.Core.TestFrameworks.Abstract.ITestFramework.Contains(System.String,System.String,System.String,System.String[])">
+            <summary>
+            Asserts that the value contains with the expected string
+            </summary>
+            <param name="actual">The actual value to test</param>
+            <param name="expected">The string with which the value is expected to contain</param>
+            <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+            <param name="parameters">An array of parameters to use when formatting message</param>
+        </member>
         <member name="M:DBConfirm.Core.TestFrameworks.Abstract.ITestFramework.DoesNotMatch(System.String,System.Text.RegularExpressions.Regex,System.String,System.String[])">
             <summary>
             Asserts that the value does not match the Regex pattern
@@ -1570,7 +1758,7 @@
             Static class to handle all assertions and validations
             </summary>
         </member>
-        <member name="M:DBConfirm.Core.Validation.ValueValidation.Assert(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Object,System.Object,System.String)">
+        <member name="M:DBConfirm.Core.Validation.ValueValidation.Assert(DBConfirm.Core.TestFrameworks.Abstract.ITestFramework,System.Object,System.Object,System.String,System.Boolean)">
             <summary>
             <para>Asserts that the value is correct, according to the expected value.</para>
             <para>Where the expected value is a native type, object equality is used as the test.  Where the expected value is an <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object, the specific <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> assertion logic is used</para>
@@ -1579,6 +1767,7 @@
             <param name="expectedValue">The expected value.  This can be either a native type or an <see cref="T:DBConfirm.Core.Comparisons.Abstract.IComparison"/> object</param>
             <param name="value">The value to test</param>
             <param name="messagePrefix">The prefix of the message to use during assertion failure</param>
+            <param name="useDBNull">Whether null values should be converted to DBNull</param>
         </member>
         <member name="M:DBConfirm.Core.Validation.ValueValidation.Validate(System.Object,System.Object)">
             <summary>

--- a/src/Core/Runners/Abstract/ITestRunner.cs
+++ b/src/Core/Runners/Abstract/ITestRunner.cs
@@ -104,6 +104,20 @@ namespace DBConfirm.Core.Runners.Abstract
         /// <exception cref="InvalidCastException"></exception>
         Task<ScalarResult<T>> ExecuteCommandScalarAsync<T>(string commandText, params SqlQueryParameter[] parameters);
         /// <summary>
+        /// Executes a command, returning the found error
+        /// </summary>
+        /// <param name="commandText">The command to execute</param>
+        /// <param name="parameters">The parameters to be used.  The Key is used as the parameter name, and the Value used as the parameter value</param>
+        /// <returns>Returns the error returned from the command. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        Task<ErrorResult> ExecuteCommandErrorAsync(string commandText, IDictionary<string, object> parameters);
+        /// <summary>
+        /// Executes a command, returning the found error
+        /// </summary>
+        /// <param name="commandText">The command to execute</param>
+        /// <param name="parameters">The parameters to be used</param>
+        /// <returns>Returns the error returned from the command. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        Task<ErrorResult> ExecuteCommandErrorAsync(string commandText, params SqlQueryParameter[] parameters);
+        /// <summary>
         /// Executes a stored procedure, returning all data tables
         /// </summary>
         /// <param name="procedureName">The name of the stored procedure, including schema</param>
@@ -171,6 +185,20 @@ namespace DBConfirm.Core.Runners.Abstract
         /// <exception cref="System.Data.Common.DbException"></exception>
         /// <exception cref="InvalidCastException"></exception>
         Task<ScalarResult<T>> ExecuteStoredProcedureScalarAsync<T>(string procedureName, params SqlQueryParameter[] parameters);
+        /// <summary>
+        /// Executes a stored procedure, returning the found error
+        /// </summary>
+        /// <param name="procedureName">The name of the stored procedure, including schema</param>
+        /// <param name="parameters">The parameters to be used.  The Key is used as the parameter name, and the Value used as the parameter value</param>
+        /// <returns>Returns the error returned from the stored procedure. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        Task<ErrorResult> ExecuteStoredProcedureErrorAsync(string procedureName, IDictionary<string, object> parameters);
+        /// <summary>
+        /// Executes a stored procedure, returning the found error
+        /// </summary>
+        /// <param name="procedureName">The name of the stored procedure, including schema</param>
+        /// <param name="parameters">The parameters to be used</param>
+        /// <returns>Returns the error returned from the stored procedure. If no error is found, then the RawData within the ErrorResult object will be null</returns>
+        Task<ErrorResult> ExecuteStoredProcedureErrorAsync(string procedureName, params SqlQueryParameter[] parameters);
         /// <summary>
         /// Returns all data for a specific table
         /// </summary>

--- a/src/Core/TestFrameworks/Abstract/ITestFramework.cs
+++ b/src/Core/TestFrameworks/Abstract/ITestFramework.cs
@@ -74,6 +74,33 @@ namespace DBConfirm.Core.TestFrameworks.Abstract
         void Matches(string value, Regex pattern, string message, params string[] parameters);
 
         /// <summary>
+        /// Asserts that the value starts with the expected string
+        /// </summary>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expected">The string with which the value is expected to start</param>
+        /// <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+        /// <param name="parameters">An array of parameters to use when formatting message</param>
+        void StartsWith(string actual, string expected, string message, params string[] parameters);
+
+        /// <summary>
+        /// Asserts that the value ends with the expected string
+        /// </summary>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expected">The string with which the value is expected to end</param>
+        /// <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+        /// <param name="parameters">An array of parameters to use when formatting message</param>
+        void EndsWith(string actual, string expected, string message, params string[] parameters);
+
+        /// <summary>
+        /// Asserts that the value contains with the expected string
+        /// </summary>
+        /// <param name="actual">The actual value to test</param>
+        /// <param name="expected">The string with which the value is expected to contain</param>
+        /// <param name="message">The message to include in the exception when the assertion fails. The message is shown in test results</param>
+        /// <param name="parameters">An array of parameters to use when formatting message</param>
+        void Contains(string actual, string expected, string message, params string[] parameters);
+
+        /// <summary>
         /// Asserts that the value does not match the Regex pattern
         /// </summary>
         /// <param name="value">The actual value to test</param>

--- a/src/Core/Validation/ValueValidation.cs
+++ b/src/Core/Validation/ValueValidation.cs
@@ -17,10 +17,14 @@ namespace DBConfirm.Core.Validation
         /// <param name="expectedValue">The expected value.  This can be either a native type or an <see cref="IComparison"/> object</param>
         /// <param name="value">The value to test</param>
         /// <param name="messagePrefix">The prefix of the message to use during assertion failure</param>
-        public static void Assert(ITestFramework testFramework, object expectedValue, object value, string messagePrefix)
+        /// <param name="useDBNull">Whether null values should be converted to DBNull</param>
+        public static void Assert(ITestFramework testFramework, object expectedValue, object value, string messagePrefix, bool useDBNull = true)
         {
-            expectedValue = expectedValue ?? DBNull.Value;
-            value = value ?? DBNull.Value;
+            if (useDBNull)
+            {
+                expectedValue = expectedValue ?? DBNull.Value;
+                value = value ?? DBNull.Value;
+            }
 
             if (expectedValue is IComparison comparisonValue)
             {

--- a/src/Databases.SQLServer/Documentation/DBConfirm.Databases.SQLServer.xml
+++ b/src/Databases.SQLServer/Documentation/DBConfirm.Databases.SQLServer.xml
@@ -92,6 +92,12 @@
         <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteStoredProcedureScalarAsync``1(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
             <inheritdoc/>
         </member>
+        <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteStoredProcedureErrorAsync(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteStoredProcedureErrorAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
+            <inheritdoc/>
+        </member>
         <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteCommandNoResultsAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
             <inheritdoc/>
         </member>
@@ -102,6 +108,12 @@
             <inheritdoc/>
         </member>
         <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteCommandAsync(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteCommandErrorAsync(System.String,DBConfirm.Core.Parameters.SqlQueryParameter[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteCommandErrorAsync(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">
             <inheritdoc/>
         </member>
         <member name="M:DBConfirm.Databases.SQLServer.Runners.SQLServerTestRunner.ExecuteCommandScalarAsync``1(System.String,System.Collections.Generic.IDictionary{System.String,System.Object})">

--- a/src/Frameworks.MSTest/Documentation/DBConfirm.Frameworks.MSTest.xml
+++ b/src/Frameworks.MSTest/Documentation/DBConfirm.Frameworks.MSTest.xml
@@ -24,6 +24,15 @@
         <member name="M:DBConfirm.Frameworks.MSTest.MSTestFramework.Matches(System.String,System.Text.RegularExpressions.Regex,System.String,System.String[])">
             <inheritdoc/>
         </member>
+        <member name="M:DBConfirm.Frameworks.MSTest.MSTestFramework.StartsWith(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Frameworks.MSTest.MSTestFramework.EndsWith(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Frameworks.MSTest.MSTestFramework.Contains(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
         <member name="M:DBConfirm.Frameworks.MSTest.MSTestFramework.DoesNotMatch(System.String,System.Text.RegularExpressions.Regex,System.String,System.String[])">
             <inheritdoc/>
         </member>

--- a/src/Frameworks.MSTest/MSTestFramework.cs
+++ b/src/Frameworks.MSTest/MSTestFramework.cs
@@ -42,6 +42,24 @@ namespace DBConfirm.Frameworks.MSTest
         }
 
         /// <inheritdoc/>
+        public void StartsWith(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.StartsWith(actual, expected, message, parameters);
+        }
+
+        /// <inheritdoc/>
+        public void EndsWith(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.EndsWith(actual, expected, message, parameters);
+        }
+
+        /// <inheritdoc/>
+        public void Contains(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.Contains(actual, expected, message, parameters);
+        }
+
+        /// <inheritdoc/>
         public void DoesNotMatch(string value, Regex pattern, string message, params string[] parameters)
         {
             StringAssert.DoesNotMatch(value, pattern, message, parameters);

--- a/src/Frameworks.NUnit/Documentation/DBConfirm.Frameworks.NUnit.xml
+++ b/src/Frameworks.NUnit/Documentation/DBConfirm.Frameworks.NUnit.xml
@@ -24,6 +24,15 @@
         <member name="M:DBConfirm.Frameworks.NUnit.NUnitFramework.Matches(System.String,System.Text.RegularExpressions.Regex,System.String,System.String[])">
             <inheritdoc/>
         </member>
+        <member name="M:DBConfirm.Frameworks.NUnit.NUnitFramework.StartsWith(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Frameworks.NUnit.NUnitFramework.EndsWith(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
+        <member name="M:DBConfirm.Frameworks.NUnit.NUnitFramework.Contains(System.String,System.String,System.String,System.String[])">
+            <inheritdoc/>
+        </member>
         <member name="M:DBConfirm.Frameworks.NUnit.NUnitFramework.DoesNotMatch(System.String,System.Text.RegularExpressions.Regex,System.String,System.String[])">
             <inheritdoc/>
         </member>

--- a/src/Frameworks.NUnit/NUnitFramework.cs
+++ b/src/Frameworks.NUnit/NUnitFramework.cs
@@ -43,6 +43,24 @@ namespace DBConfirm.Frameworks.NUnit
         }
 
         /// <inheritdoc/>
+        public void StartsWith(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.StartsWith(expected, actual, message, parameters);
+        }
+
+        /// <inheritdoc/>
+        public void EndsWith(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.EndsWith(expected, actual, message, parameters);
+        }
+
+        /// <inheritdoc/>
+        public void Contains(string actual, string expected, string message, params string[] parameters)
+        {
+            StringAssert.Contains(expected, actual, message, parameters);
+        }
+
+        /// <inheritdoc/>
         public void DoesNotMatch(string value, Regex pattern, string message, params string[] parameters)
         {
             StringAssert.DoesNotMatch(pattern.ToString(), value, message, parameters);

--- a/tests/Core.Tests/Comparisons/Strings/ContainsTests.cs
+++ b/tests/Core.Tests/Comparisons/Strings/ContainsTests.cs
@@ -1,0 +1,123 @@
+﻿using DBConfirm.Core.TestFrameworks.Abstract;
+using DBConfirm.Frameworks.MSTest;
+using NUnit.Framework;
+using System;
+using Contains = DBConfirm.Core.Comparisons.Strings.Contains;
+
+namespace Core.Tests.Comparisons.Strings;
+
+[TestFixture]
+public class ContainsTests
+{
+    private readonly ITestFramework _testFramework = new MSTestFramework();
+
+    [Test]
+    public void Contains_Ctor_SetValue_ValueSet()
+    {
+        const string value = "ABC";
+
+        Contains contains = new(value);
+
+        Assert.AreEqual(value, contains.Expected);
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void Contains_Ctor_SetValue_Empty_ThrowError(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new Contains(value));
+
+        Assert.AreEqual($"Expected string cannot be null or empty (Parameter 'expected')", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase(" is the error")]
+    [TestCase("the")]
+    [TestCase("e")]
+    [TestCase(" ")]
+    public void Contains_AssertString_Contains_NoError(string value)
+    {
+        Contains contains = new(value);
+
+        Assert.DoesNotThrow(() => contains.Assert(_testFramework, "This is the error message", "Custom message"));
+    }
+
+    [TestCase("This is the error message2")]
+    [TestCase("AThis is the error message")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("E")]
+    [TestCase("  ")]
+    public void Contains_AssertString_Contains_Error(string value)
+    {
+        Contains contains = new(value);
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => contains.Assert(_testFramework, "This is the error message", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.Contains failed. String 'This is the error message' does not contain string '{value}'. Custom message does not contain the expected string.", exception.Message);
+    }
+
+    [Test]
+    public void Contains_AssertString_Contains_ActualIsNull_Error()
+    {
+        Contains contains = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => contains.Assert(_testFramework, null, "Custom message"));
+
+        Assert.AreEqual($"Assert.IsInstanceOfType failed. Custom message is not a valid String object", exception.Message);
+    }
+
+    [Test]
+    public void Contains_AssertString_Contains_ActualIsEmpty_Error()
+    {
+        Contains contains = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => contains.Assert(_testFramework, "", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.Contains failed. String '' does not contain string 'a'. Custom message does not contain the expected string.", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase(" is the error")]
+    [TestCase("the")]
+    [TestCase("e")]
+    [TestCase(" ")]
+    public void Contains_ValidateString_Contains_True(string value)
+    {
+        Contains contains = new(value);
+
+        Assert.AreEqual(true, contains.Validate("This is the error message"));
+    }
+
+    [TestCase("This is the error message2")]
+    [TestCase("AThis is the error message")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("E")]
+    [TestCase("  ")]
+    public void Contains_ValidateString_Contains_False(string value)
+    {
+        Contains contains = new(value);
+
+        Assert.AreEqual(false, contains.Validate("This is the error message"));
+    }
+
+    [Test]
+    public void Contains_ValidateString_Contains_ActualIsNull_False()
+    {
+        Contains contains = new("a");
+
+        Assert.AreEqual(false, contains.Validate(null));
+    }
+
+    [Test]
+    public void Contains_ValidateString_Contains_ActualIsEmpty_True()
+    {
+        Contains contains = new("a");
+
+        Assert.AreEqual(false, contains.Validate(""));
+    }
+}

--- a/tests/Core.Tests/Comparisons/Strings/EndsWithTests.cs
+++ b/tests/Core.Tests/Comparisons/Strings/EndsWithTests.cs
@@ -1,0 +1,132 @@
+﻿using DBConfirm.Core.Comparisons.Strings;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using DBConfirm.Frameworks.MSTest;
+using NUnit.Framework;
+using System;
+using System.ComponentModel;
+
+namespace Core.Tests.Comparisons.Strings;
+
+[TestFixture]
+public class EndsWithTests
+{
+    private readonly ITestFramework _testFramework = new MSTestFramework();
+
+    [Test]
+    public void EndsWith_Ctor_SetValue_ValueSet()
+    {
+        const string value = "ABC";
+
+        EndsWith endswith = new(value);
+
+        Assert.AreEqual(value, endswith.Expected);
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void EndsWith_Ctor_SetValue_Empty_ThrowError(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new EndsWith(value));
+
+        Assert.AreEqual($"Expected string cannot be null or empty (Parameter 'expected')", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase(" is the error message")]
+    [TestCase("is the error message")]
+    [TestCase("error message")]
+    [TestCase("r message")]
+    [TestCase(" message")]
+    [TestCase("message")]
+    [TestCase("e")]
+    public void EndsWith_AssertString_EndsWith_NoError(string value)
+    {
+        EndsWith endswith = new(value);
+
+        Assert.DoesNotThrow(() => endswith.Assert(_testFramework, "This is the error message", "Custom message"));
+    }
+
+    [TestCase("2This is the error message")]
+    [TestCase("This is the error messageA")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("T")]
+    [TestCase("E")]
+    [TestCase(" ")]
+    public void EndsWith_AssertString_EndsWith_Error(string value)
+    {
+        EndsWith endswith = new(value);
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => endswith.Assert(_testFramework, "This is the error message", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.EndsWith failed. String 'This is the error message' does not end with string '{value}'. Custom message does not end with the expected string.", exception.Message);
+    }
+
+    [Test]
+    public void EndsWith_AssertString_EndsWith_ActualIsNull_Error()
+    {
+        EndsWith endswith = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => endswith.Assert(_testFramework, null, "Custom message"));
+
+        Assert.AreEqual($"Assert.IsInstanceOfType failed. Custom message is not a valid String object", exception.Message);
+    }
+
+    [Test]
+    public void EndsWith_AssertString_EndsWith_ActualIsEmpty_Error()
+    {
+        EndsWith endswith = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => endswith.Assert(_testFramework, "", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.EndsWith failed. String '' does not end with string 'a'. Custom message does not end with the expected string.", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase(" is the error message")]
+    [TestCase("is the error message")]
+    [TestCase("error message")]
+    [TestCase("r message")]
+    [TestCase(" message")]
+    [TestCase("message")]
+    [TestCase("e")]
+    public void EndsWith_ValidateString_EndsWith_True(string value)
+    {
+        EndsWith endswith = new(value);
+
+        Assert.AreEqual(true, endswith.Validate("This is the error message"));
+    }
+
+    [TestCase("2This is the error message")]
+    [TestCase("This is the error messageA")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("T")]
+    [TestCase("E")]
+    [TestCase(" ")]
+    public void EndsWith_ValidateString_EndsWith_False(string value)
+    {
+        EndsWith endswith = new(value);
+
+        Assert.AreEqual(false, endswith.Validate("This is the error message"));
+    }
+
+    [Test]
+    public void EndsWith_ValidateString_EndsWith_ActualIsNull_False()
+    {
+        EndsWith endswith = new("a");
+
+        Assert.AreEqual(false, endswith.Validate(null));
+    }
+
+    [Test]
+    public void EndsWith_ValidateString_EndsWith_ActualIsEmpty_False()
+    {
+        EndsWith endswith = new("a");
+
+        Assert.AreEqual(false, endswith.Validate(""));
+    }
+}

--- a/tests/Core.Tests/Comparisons/Strings/StartsWithTests.cs
+++ b/tests/Core.Tests/Comparisons/Strings/StartsWithTests.cs
@@ -1,0 +1,127 @@
+﻿using DBConfirm.Core.Comparisons.Strings;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using DBConfirm.Frameworks.MSTest;
+using NUnit.Framework;
+using System;
+
+namespace Core.Tests.Comparisons.Strings;
+
+[TestFixture]
+public class StartsWithTests
+{
+    private readonly ITestFramework _testFramework = new MSTestFramework();
+
+    [Test]
+    public void StartsWith_Ctor_SetValue_ValueSet()
+    {
+        const string value = "ABC";
+
+        StartsWith startswith = new(value);
+
+        Assert.AreEqual(value, startswith.Expected);
+    }
+
+    [TestCase("")]
+    [TestCase(null)]
+    public void StartsWith_Ctor_SetValue_Empty_ThrowError(string value)
+    {
+        var exception = Assert.Throws<ArgumentException>(() => new StartsWith(value));
+
+        Assert.AreEqual($"Expected string cannot be null or empty (Parameter 'expected')", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase("This is the")]
+    [TestCase("This is ")]
+    [TestCase("This ")]
+    [TestCase("This")]
+    [TestCase("T")]
+    public void StartsWith_AssertString_StartsWith_NoError(string value)
+    {
+        StartsWith startswith = new(value);
+
+        Assert.DoesNotThrow(() => startswith.Assert(_testFramework, "This is the error message", "Custom message"));
+    }
+
+    [TestCase("This is the error message2")]
+    [TestCase("AThis is the error message")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("E")]
+    [TestCase("t")]
+    [TestCase(" ")]
+    public void StartsWith_AssertString_StartsWith_False(string value)
+    {
+        StartsWith startswith = new(value);
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => startswith.Assert(_testFramework, "This is the error message", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.StartsWith failed. String 'This is the error message' does not start with string '{value}'. Custom message does not start with the expected string.", exception.Message);
+    }
+
+    [Test]
+    public void StartsWith_AssertString_StartsWith_ActualIsNull_False()
+    {
+        StartsWith startswith = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => startswith.Assert(_testFramework, null, "Custom message"));
+
+        Assert.AreEqual($"Assert.IsInstanceOfType failed. Custom message is not a valid String object", exception.Message);
+    }
+
+    [Test]
+    public void StartsWith_AssertString_StartsWith_ActualIsEmpty_False()
+    {
+        StartsWith startswith = new("a");
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(()
+            => startswith.Assert(_testFramework, "", "Custom message"));
+
+        Assert.AreEqual($"StringAssert.StartsWith failed. String '' does not start with string 'a'. Custom message does not start with the expected string.", exception.Message);
+    }
+
+    [TestCase("This is the error message")]
+    [TestCase("This is the")]
+    [TestCase("This is ")]
+    [TestCase("This ")]
+    [TestCase("This")]
+    [TestCase("T")]
+    public void StartsWith_ValidateString_StartsWith_True(string value)
+    {
+        StartsWith startswith = new(value);
+
+        Assert.AreEqual(true, startswith.Validate("This is the error message"));
+    }
+
+    [TestCase("This is the error message2")]
+    [TestCase("AThis is the error message")]
+    [TestCase("there")]
+    [TestCase("THIS IS THE ERROR MESSAGE")]
+    [TestCase("E")]
+    [TestCase("t")]
+    [TestCase(" ")]
+    public void StartsWith_ValidateString_StartsWith_False(string value)
+    {
+        StartsWith startswith = new(value);
+
+        Assert.AreEqual(false, startswith.Validate("This is the error message"));
+    }
+
+    [Test]
+    public void StartsWith_ValidateString_StartsWith_ActualIsNull_False()
+    {
+        StartsWith startswith = new("a");
+
+        Assert.AreEqual(false, startswith.Validate(null));
+    }
+
+    [Test]
+    public void StartsWith_ValidateString_StartsWith_ActualIsEmpty_False()
+    {
+        StartsWith startswith = new("a");
+
+        Assert.AreEqual(false, startswith.Validate(""));
+    }
+}

--- a/tests/Core.Tests/DataResults/ErrorResultTests.cs
+++ b/tests/Core.Tests/DataResults/ErrorResultTests.cs
@@ -1,0 +1,69 @@
+﻿using DBConfirm.Core.DataResults;
+using DBConfirm.Core.TestFrameworks.Abstract;
+using NUnit.Framework;
+using DBConfirm.Frameworks.MSTest;
+using System;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace Core.Tests.DataResults;
+
+[TestFixture]
+public class ErrorResultTests
+{
+    private readonly ITestFramework _testFramework = new MSTestFramework();
+
+    [Test]
+    public void ErrorResult_Ctor_NullValue_ValueSet()
+    {
+        ErrorResult result = new(_testFramework, null);
+
+        Assert.AreEqual(null, result.RawData);
+    }
+
+    [Test]
+    public void ErrorResult_Ctor_WithException_ValueSet()
+    {
+        var error = new NullReferenceException();
+
+        ErrorResult result = new(_testFramework, error);
+
+        Assert.AreEqual(error, result.RawData);
+    }
+
+    [Test]
+    public void ErrorResult_AssertType_ValueMatches_NoError()
+    {
+        var error = new NullReferenceException();
+
+        ErrorResult result = new(_testFramework, error);
+
+        Assert.DoesNotThrow(() =>
+            result.AssertType(typeof(NullReferenceException)));
+    }
+
+    [Test]
+    public void ErrorResult_AssertType_ValueDoesNotMatch_Error()
+    {
+        var error = new NullReferenceException();
+
+        ErrorResult result = new(_testFramework, error);
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(() =>
+           result.AssertType(typeof(InsufficientMemoryException)));
+
+        Assert.AreEqual("Assert.AreEqual failed. Expected:<System.InsufficientMemoryException>. Actual:<System.NullReferenceException>. Error result has an unexpected value", exception.Message);
+    }
+
+    [Test]
+    public void ErrorResult_AssertType_ValueDoesNotMatchExpectedIsNull_Error()
+    {
+        var error = new NullReferenceException();
+
+        ErrorResult result = new(_testFramework, error);
+
+        var exception = Assert.Throws<Microsoft.VisualStudio.TestTools.UnitTesting.AssertFailedException>(() =>
+           result.AssertType(null));
+
+        Assert.AreEqual("Assert.AreEqual failed. Expected:<(null)>. Actual:<System.NullReferenceException>. Error result has an unexpected value", exception.Message);
+    }
+}

--- a/tests/Sample.Core.MSTest.Tests/StoredProcedures/AddUserTests.cs
+++ b/tests/Sample.Core.MSTest.Tests/StoredProcedures/AddUserTests.cs
@@ -446,7 +446,7 @@ public class AddUserTests : MSTestBase
         }
         catch (Exception ex)
         {
-            Assert.AreEqual("StringAssert.StartsWith failed. String 'Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.\r\nThe statement has been terminated.' does not start with string 'Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.'. Error result does not start with the expected string.", ex.Message);
+            Assert.AreEqual($"StringAssert.StartsWith failed. String 'Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.{Environment.NewLine}The statement has been terminated.' does not start with string 'Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.'. Error result does not start with the expected string.", ex.Message);
             return;
         }
 

--- a/tests/Sample.Core.MSTest.Tests/StoredProcedures/AddUserTests.cs
+++ b/tests/Sample.Core.MSTest.Tests/StoredProcedures/AddUserTests.cs
@@ -1,10 +1,13 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Threading.Tasks;
+﻿using DBConfirm.Core.Data;
 using DBConfirm.Core.DataResults;
-using DBConfirm.Core.Data;
 using DBConfirm.Core.Parameters;
 using DBConfirm.Packages.SQLServer.MSTest;
+using Microsoft.Data.SqlClient;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Sample.Core.MSTest.Tests.StoredProcedures;
 
@@ -176,5 +179,333 @@ public class AddUserTests : MSTestBase
             }));
 
         Assert.AreEqual($"Assert.Fail failed. Row 1 matches the expected data that should not match anything: {Environment.NewLine}[FirstName, AAA]{Environment.NewLine}[LastName, FFF]", exception.Message);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_NullRequiredParameter_ExpectError(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", null),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        error.AssertError();
+        error.AssertType(typeof(SqlException));
+        error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_ValidRequest_AssertError_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", "AAA"),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        try
+        {
+            error.AssertError();
+        }
+        catch (Exception ex)
+        {
+            Assert.AreEqual("Assert.Fail failed. No error was found", ex.Message);
+            return;
+        }
+
+        Assert.Fail("Expected test to fail, but it passed");
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_ValidRequest_AssertErrorType_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", "AAA"),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        try
+        {
+            error.AssertType(typeof(SqlException));
+        }
+        catch (Exception ex)
+        {
+            Assert.AreEqual("Assert.Fail failed. No error was found", ex.Message);
+            return;
+        }
+
+        Assert.Fail("Expected test to fail, but it passed");
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_ValidRequest_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", "AAA"),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        try
+        {
+            error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+        }
+        catch (Exception ex)
+        {
+            Assert.AreEqual("Assert.Fail failed. No error was found", ex.Message);
+            return;
+        }
+
+        Assert.Fail("Expected test to fail, but it passed");
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_InvalidRequest_ExpectIncorrectMessage_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", null),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        try
+        {
+            error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+        }
+        catch (Exception ex)
+        {
+            Assert.AreEqual("StringAssert.StartsWith failed. String 'Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.\r\nThe statement has been terminated.' does not start with string 'Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.'. Error result does not start with the expected string.", ex.Message);
+            return;
+        }
+
+        Assert.Fail("Expected test to fail, but it passed");
+    }
+
+    [DataTestMethod]
+    [DataRow(true, true)]
+    [DataRow(false, true)]
+    [DataRow(true, false)]
+    [DataRow(false, false)]
+    public async Task AddUser_InvalidRequest_ExpectIncorrectType_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", null),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        try
+        {
+            error.AssertType(typeof(NullReferenceException));
+        }
+        catch (Exception ex)
+        {
+            Assert.AreEqual("Assert.AreEqual failed. Expected:<System.NullReferenceException>. Actual:<Microsoft.Data.SqlClient.SqlException>. Error result has an unexpected value", ex.Message);
+            return;
+        }
+
+        Assert.Fail("Expected test to fail, but it passed");
     }
 }

--- a/tests/Sample.Core.NUnit.Tests/StoredProcedures/AddUserTests.cs
+++ b/tests/Sample.Core.NUnit.Tests/StoredProcedures/AddUserTests.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using DBConfirm.Core.Data;
 using DBConfirm.Core.DataResults;
-using DBConfirm.Core.Data;
 using DBConfirm.Core.Parameters;
 using DBConfirm.Packages.SQLServer.NUnit;
+using Microsoft.Data.SqlClient;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Sample.Core.NUnit.Tests.StoredProcedures;
 
@@ -175,5 +179,342 @@ public class AddUserTests : NUnitBase
             }));
 
         Assert.AreEqual($"Row 1 matches the expected data that should not match anything: {Environment.NewLine}[FirstName, AAA]{Environment.NewLine}[LastName, FFF]", exception.Message);
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_NullRequiredParameter_ExpectError(bool useProcedure, bool useSqlParameters)
+    {
+        SqlQueryParameter[] parameters =
+        [
+            new("FirstName", null),
+            new("LastName", "FFF"),
+            new("EmailAddress", "AAA@FFF.co.uk"),
+            new("StartDate", DateTime.Parse("01-Jan-2020")),
+            new("NumberOfHats", 3),
+            new("Cost", 34)
+        ];
+
+        Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+        ErrorResult error;
+        if (useProcedure)
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+            }
+        }
+        else
+        {
+            if (useSqlParameters)
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+            }
+            else
+            {
+                error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+            }
+        }
+
+        error.AssertError();
+        error.AssertType(typeof(SqlException));
+        error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_ValidRequest_AssertError_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            SqlQueryParameter[] parameters =
+            [
+                new("FirstName", "AAA"),
+                new("LastName", "FFF"),
+                new("EmailAddress", "AAA@FFF.co.uk"),
+                new("StartDate", DateTime.Parse("01-Jan-2020")),
+                new("NumberOfHats", 3),
+                new("Cost", 34)
+            ];
+
+            Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+            ErrorResult error;
+            if (useProcedure)
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+                }
+            }
+            else
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+                }
+            }
+
+            try
+            {
+                error.AssertError();
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual("No error was found", ex.Message);
+                return;
+            }
+
+            Assert.Fail("Expected test to fail, but it passed");
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_ValidRequest_AssertErrorType_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            SqlQueryParameter[] parameters =
+            [
+                new("FirstName", "AAA"),
+                new("LastName", "FFF"),
+                new("EmailAddress", "AAA@FFF.co.uk"),
+                new("StartDate", DateTime.Parse("01-Jan-2020")),
+                new("NumberOfHats", 3),
+                new("Cost", 34)
+            ];
+
+            Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+            ErrorResult error;
+            if (useProcedure)
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+                }
+            }
+            else
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+                }
+            }
+
+            try
+            {
+                error.AssertType(typeof(SqlException));
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual("No error was found", ex.Message);
+                return;
+            }
+
+            Assert.Fail("Expected test to fail, but it passed");
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_ValidRequest_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            SqlQueryParameter[] parameters =
+            [
+                new("FirstName", "AAA"),
+                new("LastName", "FFF"),
+                new("EmailAddress", "AAA@FFF.co.uk"),
+                new("StartDate", DateTime.Parse("01-Jan-2020")),
+                new("NumberOfHats", 3),
+                new("Cost", 34)
+            ];
+
+            Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+            ErrorResult error;
+            if (useProcedure)
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+                }
+            }
+            else
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+                }
+            }
+
+            try
+            {
+                error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual("No error was found", ex.Message);
+                return;
+            }
+
+            Assert.Fail("Expected test to fail, but it passed");
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_InvalidRequest_ExpectIncorrectMessage_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            SqlQueryParameter[] parameters =
+            [
+                new("FirstName", null),
+                new("LastName", "FFF"),
+                new("EmailAddress", "AAA@FFF.co.uk"),
+                new("StartDate", DateTime.Parse("01-Jan-2020")),
+                new("NumberOfHats", 3),
+                new("Cost", 34)
+            ];
+
+            Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+            ErrorResult error;
+            if (useProcedure)
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+                }
+            }
+            else
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+                }
+            }
+
+            try
+            {
+                error.AssertMessage(Comparisons.StartsWith("Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls."));
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual("  Error result does not start with the expected string\r\n  Expected: String starting with \"Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.\"\r\n  But was:  \"Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.\r\nThe statement has been terminated.\"\r\n", ex.Message);
+                return;
+            }
+
+            Assert.Fail("Expected test to fail, but it passed");
+        }
+    }
+
+    [TestCase(true, true)]
+    [TestCase(false, true)]
+    [TestCase(true, false)]
+    [TestCase(false, false)]
+    public async Task AddUser_InvalidRequest_ExpectIncorrectType_AssertErrorMessage_ShouldFailTest(bool useProcedure, bool useSqlParameters)
+    {
+        using (new TestExecutionContext.IsolatedContext())
+        {
+            SqlQueryParameter[] parameters =
+            [
+                new("FirstName", null),
+                new("LastName", "FFF"),
+                new("EmailAddress", "AAA@FFF.co.uk"),
+                new("StartDate", DateTime.Parse("01-Jan-2020")),
+                new("NumberOfHats", 3),
+                new("Cost", 34)
+            ];
+
+            Dictionary<string, object> dictionary = parameters.ToDictionary(p => p.ParameterName, p => p.Value);
+
+            ErrorResult error;
+            if (useProcedure)
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteStoredProcedureErrorAsync("dbo.AddUser", dictionary);
+                }
+            }
+            else
+            {
+                if (useSqlParameters)
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", parameters);
+                }
+                else
+                {
+                    error = await TestRunner.ExecuteCommandErrorAsync("EXEC dbo.AddUser @FirstName, @LastName, @EmailAddress, @StartDate, @NumberOfHats, @Cost", dictionary);
+                }
+            }
+
+            try
+            {
+                error.AssertType(typeof(NullReferenceException));
+            }
+            catch (Exception ex)
+            {
+                Assert.AreEqual("  Error result has an unexpected value\r\n  Expected: <System.NullReferenceException>\r\n  But was:  <Microsoft.Data.SqlClient.SqlException>\r\n", ex.Message);
+                return;
+            }
+
+            Assert.Fail("Expected test to fail, but it passed");
+        }
     }
 }

--- a/tests/Sample.Core.NUnit.Tests/StoredProcedures/AddUserTests.cs
+++ b/tests/Sample.Core.NUnit.Tests/StoredProcedures/AddUserTests.cs
@@ -452,7 +452,7 @@ public class AddUserTests : NUnitBase
             }
             catch (Exception ex)
             {
-                Assert.AreEqual("  Error result does not start with the expected string\r\n  Expected: String starting with \"Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.\"\r\n  But was:  \"Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.\r\nThe statement has been terminated.\"\r\n", ex.Message);
+                Assert.AreEqual($"  Error result does not start with the expected string{Environment.NewLine}  Expected: String starting with \"Cannot insert the value NULL into column 'LastName', table 'SampleDB.dbo.Users'; column does not allow nulls.\"{Environment.NewLine}  But was:  \"Cannot insert the value NULL into column 'FirstName', table 'SampleDB.dbo.Users'; column does not allow nulls. INSERT fails.{Environment.NewLine}The statement has been terminated.\"{Environment.NewLine}", ex.Message);
                 return;
             }
 
@@ -510,7 +510,7 @@ public class AddUserTests : NUnitBase
             }
             catch (Exception ex)
             {
-                Assert.AreEqual("  Error result has an unexpected value\r\n  Expected: <System.NullReferenceException>\r\n  But was:  <Microsoft.Data.SqlClient.SqlException>\r\n", ex.Message);
+                Assert.AreEqual($"  Error result has an unexpected value{Environment.NewLine}  Expected: <System.NullReferenceException>{Environment.NewLine}  But was:  <Microsoft.Data.SqlClient.SqlException>{Environment.NewLine}", ex.Message);
                 return;
             }
 

--- a/tests/Sample.Northwind.MSTest.Tests/Data/UniquenessTests.cs
+++ b/tests/Sample.Northwind.MSTest.Tests/Data/UniquenessTests.cs
@@ -165,7 +165,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow("03-Mar-2023", "04-Mar-2023")]
     [DataRow("03-Mar-2023 09:23:23", "03-Mar-2023 09:23:24")]
     [DataRow("03-Mar-2023 09:23:23.001", "03-Mar-2023 09:23:23.002")]
@@ -266,7 +266,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(1, 2)]
     [DataRow(10000, 10001)]
     public async Task IntType_AllUnique_AssertColumnValuesUniqueTrue(int value1, int value2)
@@ -292,7 +292,7 @@ public class UniquenessTests : MSTestBase
             .AssertColumnValuesUnique("Quantity");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(1)]
     [DataRow(1001)]
     public async Task IntType_SingleColumnNotUnique_AssertColumnValuesUniqueTrue(int value)
@@ -334,7 +334,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(1.0, 2.0)]
     [DataRow(10000, 10001)]
     [DataRow(1.01, 1.02)]
@@ -361,7 +361,7 @@ public class UniquenessTests : MSTestBase
             .AssertColumnValuesUnique("UnitPrice");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(1)]
     [DataRow(1001)]
     [DataRow(100.01)]
@@ -404,7 +404,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(0f, 0.1f)]
     [DataRow(0.001f, 0.002f)]
     [DataRow(0.999f, 0.998f)]
@@ -431,7 +431,7 @@ public class UniquenessTests : MSTestBase
             .AssertColumnValuesUnique("Discount");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(0f)]
     [DataRow(0.1f)]
     [DataRow(0.001f)]
@@ -476,7 +476,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(true, false)]
     [DataRow(false, true)]
     public async Task BoolType_AllUnique_AssertColumnValuesUniqueTrue(bool value1, bool value2)
@@ -494,7 +494,7 @@ public class UniquenessTests : MSTestBase
             .AssertColumnValuesUnique("Discontinued");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow(true)]
     [DataRow(false)]
     public async Task BoolType_SingleColumnNotUnique_AssertColumnValuesUniqueTrue(bool value)
@@ -525,7 +525,7 @@ public class UniquenessTests : MSTestBase
         Assert.Fail("Expected test to fail, but it passed");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow("A", "B")]
     [DataRow("A", "")]
     [DataRow("", "A")]
@@ -548,7 +548,7 @@ public class UniquenessTests : MSTestBase
             .AssertColumnValuesUnique("CategoryName");
     }
 
-    [TestMethod]
+    [DataTestMethod]
     [DataRow("A")]
     [DataRow("")]
     [DataRow(" ")]


### PR DESCRIPTION
… an error, and added assertions to check whether the error was raised, check the message and check the type.  Updated documentation and added tests.

As part of this I also added extra string comparison objects, for checking Contains, StartsWith and EndsWith, since it would be easier to check for the start (or middle) of a SqlException message than having to get the entire message exactly right (including new line characters, etc.).